### PR TITLE
Potential fix for code scanning alert no. 20: Partial server-side request forgery

### DIFF
--- a/apis/repo-health-check/app.py
+++ b/apis/repo-health-check/app.py
@@ -178,6 +178,10 @@ def check_gitlab_health(owner: str, repo: str, token: Optional[str] = None) -> H
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner):
         raise ValueError("Invalid owner parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
 
+    # Validate the repo parameter
+    if not re.match(r"^[a-zA-Z0-9_-]+$", repo):
+        raise ValueError("Invalid repo parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
+
     headers = get_gitlab_headers(token)
     result = HealthCheckResult(
         repository_url=f"https://gitlab.com/{owner}/{repo}",


### PR DESCRIPTION
Potential fix for [https://github.com/zchryr/health/security/code-scanning/20](https://github.com/zchryr/health/security/code-scanning/20)

To fix the issue, we need to validate the `repo` parameter to ensure it only contains safe characters. This can be achieved by applying a regular expression check similar to the one used for the `owner` parameter. The validation should ensure that `repo` only contains alphanumeric characters, dashes, and underscores, which are typical for repository names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
