### PR TITLE
Potential fix for code scanning alert no. 19: Partial server-side request forgery

### DIFF
--- a/apis/repo-health-check/app.py
+++ b/apis/repo-health-check/app.py
@@ -178,6 +178,10 @@ def check_gitlab_health(owner: str, repo: str, token: Optional[str] = None) -> H
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner):
         raise ValueError("Invalid owner parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
 
+    # Validate the repo parameter
+    if not re.match(r"^[a-zA-Z0-9_-]+$", repo):
+        raise ValueError("Invalid repo parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
+
     headers = get_gitlab_headers(token)
     result = HealthCheckResult(
         repository_url=f"https://gitlab.com/{owner}/{repo}",


### PR DESCRIPTION
Potential fix for [https://github.com/zchryr/health/security/code-scanning/19](https://github.com/zchryr/health/security/code-scanning/19)

To fix the issue, we need to validate the `repo` parameter to ensure it adheres to a safe and expected format. This can be done by applying a regular expression to restrict the `repo` value to alphanumeric characters, dashes, and underscores, which are typical for repository names. This validation should be added in the `check_gitlab_health` function before constructing the `file_url`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
