### PR TITLE
Potential fix for code scanning alert no. 16: Partial server-side request forgery

### DIFF
--- a/apis/repo-health-check/app.py
+++ b/apis/repo-health-check/app.py
@@ -111,6 +111,10 @@ def check_github_health(owner: str, repo: str, token: Optional[str] = None) -> H
     """
     Perform health checks on a GitHub repository.
     """
+    # Validate the owner parameter
+    if not re.match(r"^[a-zA-Z0-9_-]+$", owner):
+        raise ValueError("Invalid owner parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
+
     headers = get_github_headers(token)
     result = HealthCheckResult(
         repository_url=f"https://github.com/{owner}/{repo}",


### PR DESCRIPTION
Potential fix for [https://github.com/zchryr/health/security/code-scanning/16](https://github.com/zchryr/health/security/code-scanning/16)

To fix the issue, we need to validate the `owner` parameter to ensure it only contains safe and expected values. A common approach is to restrict the `owner` parameter to alphanumeric characters, dashes, and underscores, which are typical for GitHub repository owners. This can be achieved using a regular expression.

Steps to implement the fix:
1. Add a validation step for the `owner` parameter in the `check_github_health` function.
2. Use a regular expression to ensure the `owner` parameter only contains valid characters.
3. If the validation fails, raise an appropriate exception to prevent further processing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
