### PR TITLE
Potential fix for code scanning alert no. 15: Partial server-side request forgery

### DIFF
--- a/apis/repo-health-check/app.py
+++ b/apis/repo-health-check/app.py
@@ -107,10 +107,21 @@ def get_gitlab_headers(token: Optional[str] = None) -> Dict[str, str]:
         headers["PRIVATE-TOKEN"] = token
     return headers
 
+def validate_github_username(username: str) -> bool:
+    """
+    Validate that the given string is a valid GitHub username.
+    GitHub usernames must be alphanumeric, can include hyphens, but cannot start or end with a hyphen.
+    They must be between 1 and 39 characters long.
+    """
+    return bool(re.match(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$", username))
+
 def check_github_health(owner: str, repo: str, token: Optional[str] = None) -> HealthCheckResult:
     """
     Perform health checks on a GitHub repository.
     """
+    if not validate_github_username(owner):
+        raise ValueError(f"Invalid GitHub username: {owner}")
+
     headers = get_github_headers(token)
     result = HealthCheckResult(
         repository_url=f"https://github.com/{owner}/{repo}",


### PR DESCRIPTION
Potential fix for [https://github.com/zchryr/health/security/code-scanning/15](https://github.com/zchryr/health/security/code-scanning/15)

To fix the issue, we need to validate the `owner` parameter to ensure it adheres to the expected format for GitHub usernames. GitHub usernames are alphanumeric and can include hyphens, but they cannot start or end with a hyphen, and they must be between 1 and 39 characters long. By enforcing these constraints, we can prevent malicious input from being used to construct the `issues_url`.

The fix involves:
1. Adding a validation function to check the format of the `owner` parameter.
2. Using this validation function in the `check_github_health` function to reject invalid `owner` values before constructing the `issues_url`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
