### PR TITLE
Potential fix for code scanning alert no. 20: Partial server-side request forgery

### DIFF
--- a/apis/repo-health-check/app.py
+++ b/apis/repo-health-check/app.py
@@ -184,6 +184,10 @@ def check_gitlab_health(owner: str, repo: str, token: Optional[str] = None) -> H
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner):
         raise ValueError("Invalid owner parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
 
+    # Validate the repo parameter
+    if not re.match(r"^[a-zA-Z0-9_-]+$", repo):
+        raise ValueError("Invalid repo parameter. Only alphanumeric characters, dashes, and underscores are allowed.")
+
     headers = get_gitlab_headers(token)
     result = HealthCheckResult(
         repository_url=f"https://gitlab.com/{owner}/{repo}",


### PR DESCRIPTION
Potential fix for [https://github.com/zchryr/health/security/code-scanning/20](https://github.com/zchryr/health/security/code-scanning/20)

To fix the issue, we need to validate the `repo` parameter to ensure it adheres to a strict format, similar to the validation applied to the `owner` parameter. This will prevent malicious input from being used to manipulate the URL. Specifically:
1. Add a validation step for the `repo` parameter to ensure it only contains alphanumeric characters, dashes, and underscores.
2. Reject any input that does not conform to this format by raising an appropriate exception.

The changes will be made in the `check_gitlab_health` function, where the `repo` parameter is first used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
